### PR TITLE
Added launch settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 # StyleCop
 StyleCopReport.xml

--- a/UserApi/UserApi/Properties/launchSettings.json
+++ b/UserApi/UserApi/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+    "iisSettings": {
+      "windowsAuthentication": false,
+      "anonymousAuthentication": true,
+      "iisExpress": {
+        "applicationUrl": "http://localhost:50766",
+        "sslPort": 44378
+      }
+    },
+    "profiles": {
+      "IIS Express": {
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "https://localhost:5200;http://localhost:5201"
+      },
+      "UserApi": {
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "https://localhost:5200;http://localhost:5201"
+      }
+    }
+  }


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
I added the `launchSettings.json` file to the project so the api is hosted on `:5200` for everyone.

The file is normally excluded in `.gitignore` since it may be different between dev environments. In our case, since we have the url in the user secrets which is shared between all of us, I think we can use the same launchsettings.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
