### PR TITLE
Vih 3839 polly on deleting users

### DIFF
--- a/UserApi/Testing.Common/ActiveDirectory/ActiveDirectoryUser.cs
+++ b/UserApi/Testing.Common/ActiveDirectory/ActiveDirectoryUser.cs
@@ -37,23 +37,23 @@ namespace Testing.Common.ActiveDirectory
             }
         }
 
-        public static bool DeleteTheUserFromAd(string user, string token)
+        public static async Task<bool> DeleteTheUserFromAd(string user, string token)
         {
             
             var tenantId = TestConfig.Instance.AzureAd.TenantId;
             var policy = Policy.HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.NotFound)
-                .WaitAndRetry(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
            
             
             // sometimes the api can be slow to actually allow us to access the created instance, so retry if it fails the first time
-            var result = policy.Execute(() =>
+            var result = await policy.ExecuteAsync(() =>
             {
                 using (var client = new HttpClient())
                 {
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                     var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete,
                     $@"https://graph.microsoft.com/v1.0/{tenantId}/users/{user}");
-                    return client.SendAsync(httpRequestMessage).Result;
+                    return client.SendAsync(httpRequestMessage);
                 }
             });
             

--- a/UserApi/Testing.Common/ActiveDirectory/ActiveDirectoryUser.cs
+++ b/UserApi/Testing.Common/ActiveDirectory/ActiveDirectoryUser.cs
@@ -46,14 +46,14 @@ namespace Testing.Common.ActiveDirectory
            
             
             // sometimes the api can be slow to actually allow us to access the created instance, so retry if it fails the first time
-            var result = await policy.ExecuteAsync(() =>
+            var result = await policy.ExecuteAsync(async () =>
             {
                 using (var client = new HttpClient())
                 {
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                     var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete,
                     $@"https://graph.microsoft.com/v1.0/{tenantId}/users/{user}");
-                    return client.SendAsync(httpRequestMessage);
+                    return await client.SendAsync(httpRequestMessage);
                 }
             });
             

--- a/UserApi/Testing.Common/TestConfig.cs
+++ b/UserApi/Testing.Common/TestConfig.cs
@@ -1,8 +1,8 @@
 using Microsoft.Extensions.Configuration;
-using Testing.Common;
+using UserApi;
 using UserApi.Common;
 
-namespace UserApi.IntegrationTests
+namespace Testing.Common
 {
     public class TestConfig
     {

--- a/UserApi/Testing.Common/Testing.Common.csproj
+++ b/UserApi/Testing.Common/Testing.Common.csproj
@@ -8,10 +8,14 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
       <PackageReference Include="NBuilder" Version="6.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+      <PackageReference Include="Microsoft.AspNetCore.All" />
+      <PackageReference Include="Polly" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\UserApi.Common\UserApi.Common.csproj" />
       <ProjectReference Include="..\UserApi.Contract\UserApi.Contract.csproj" />
+      <ProjectReference Include="..\UserApi\UserApi.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/UserApi/UserApi.AcceptanceTests/Steps/UserSteps.cs
+++ b/UserApi/UserApi.AcceptanceTests/Steps/UserSteps.cs
@@ -1,4 +1,5 @@
-﻿using Faker;
+﻿using System.Threading.Tasks;
+using Faker;
 using FluentAssertions;
 using TechTalk.SpecFlow;
 using Testing.Common.ActiveDirectory;
@@ -76,10 +77,10 @@ namespace UserApi.AcceptanceTests.Steps
         }
 
         [AfterScenario]
-        public void NewUserClearUp()
+        public async Task NewUserClearUp()
         {
             if (string.IsNullOrWhiteSpace(_acTestContext.NewUserId)) return;
-            var userDeleted = ActiveDirectoryUser.DeleteTheUserFromAd(_acTestContext.NewUserId, _acTestContext.GraphApiToken);
+            var userDeleted = await ActiveDirectoryUser.DeleteTheUserFromAd(_acTestContext.NewUserId, _acTestContext.GraphApiToken);
             userDeleted.Should().BeTrue($"New user with ID {_acTestContext.NewUserId} is deleted");
             _acTestContext.NewUserId = null;
         }

--- a/UserApi/UserApi.IntegrationTests/Hooks/ApiHooks.cs
+++ b/UserApi/UserApi.IntegrationTests/Hooks/ApiHooks.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Options;
 using TechTalk.SpecFlow;
+using Testing.Common;
 using UserApi.IntegrationTests.Contexts;
 using UserApi.Security;
 

--- a/UserApi/UserApi.IntegrationTests/Services/ActiveDirectoryUserAccountServiceTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Services/ActiveDirectoryUserAccountServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using Testing.Common;
 using UserApi.Common;
 using UserApi.Helper;
 using UserApi.Security;

--- a/UserApi/UserApi.IntegrationTests/Services/GraphApiClientTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Services/GraphApiClientTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using Testing.Common;
 using UserApi.Common;
 using UserApi.Helper;
 using UserApi.Security;

--- a/UserApi/UserApi.IntegrationTests/Steps/UserSteps.cs
+++ b/UserApi/UserApi.IntegrationTests/Steps/UserSteps.cs
@@ -223,10 +223,10 @@ namespace UserApi.IntegrationTests.Steps
         }
 
         [AfterScenario]
-        public void ClearUp()
+        public async Task ClearUp()
         {
             if (string.IsNullOrWhiteSpace(_apiTestContext.NewUserId)) return;
-            var userDeleted = ActiveDirectoryUser.DeleteTheUserFromAd(_apiTestContext.NewUserId, _apiTestContext.GraphApiToken);
+            var userDeleted = await ActiveDirectoryUser.DeleteTheUserFromAd(_apiTestContext.NewUserId, _apiTestContext.GraphApiToken);
             userDeleted.Should().BeTrue($"New user with ID {_apiTestContext.NewUserId} is deleted");
             _apiTestContext.NewUserId = null;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-3839

### Change description ###
Added in polly to retry on user deletion. It's needed for next step when user creation will complete before the user is fully instantiated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
