### PR TITLE
Replaced usages of IOptions

### DIFF
--- a/UserApi/Testing.Common/TestConfig.cs
+++ b/UserApi/Testing.Common/TestConfig.cs
@@ -5,23 +5,25 @@ using UserApi.Common;
 namespace Testing.Common
 {
     public class TestConfig
-    {
+    {        
+        private readonly IConfigurationRoot _configuration;
+
         private TestConfig()
         {
             var configRootBuilder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
                 .AddUserSecrets<Startup>();
 
-            var config = configRootBuilder.Build();
-            
+            _configuration = configRootBuilder.Build();
+
             AzureAd = new AzureAdConfiguration();
-            config.GetSection("AzureAd").Bind(AzureAd);
+            _configuration.GetSection("AzureAd").Bind(AzureAd);
 
             TestSettings = new TestSettings();
-            config.GetSection("Testing").Bind(TestSettings);
+            _configuration.GetSection("Testing").Bind(TestSettings);
             
             Settings = new Settings();
-            config.Bind(Settings);
+            _configuration.Bind(Settings);
         }
         
         public AzureAdConfiguration AzureAd { get; }
@@ -29,8 +31,12 @@ namespace Testing.Common
         public TestSettings TestSettings { get; }
         
         public Settings Settings { get; set; }
-        
 
+        public TType GetFromSection<TType>(string sectionName)
+        {
+            return _configuration.GetSection(sectionName).Get<TType>();
+        }
+        
         public static readonly TestConfig Instance = new TestConfig();
     }
 }

--- a/UserApi/UserApi.AcceptanceTests/Steps/BaseSteps.cs
+++ b/UserApi/UserApi.AcceptanceTests/Steps/BaseSteps.cs
@@ -22,32 +22,19 @@ namespace UserApi.AcceptanceTests.Steps
         [BeforeTestRun]
         public static void OneTimeSetup(AcTestContext testContext)
         {
-            var configRootBuilder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .AddEnvironmentVariables()
-                .AddUserSecrets<Startup>();
+            var azureAdConfiguration = TestConfig.Instance.AzureAd;
+            testContext.TestSettings = TestConfig.Instance.TestSettings;
 
-            var configRoot = configRootBuilder.Build();
-
-            var azureAdConfigurationOptions =
-                Options.Create(configRoot.GetSection("AzureAd").Get<AzureAdConfiguration>());
-            var testSettingsOptions = Options.Create(configRoot.GetSection("Testing").Get<TestSettings>());
-
-            var azureAdConfiguration = azureAdConfigurationOptions.Value;
-            testContext.TestSettings = testSettingsOptions.Value;
-
-            testContext.BearerToken = new TokenProvider(azureAdConfigurationOptions).GetClientAccessToken(
+            testContext.BearerToken = new TokenProvider(azureAdConfiguration).GetClientAccessToken(
                 testContext.TestSettings.TestClientId, testContext.TestSettings.TestClientSecret,
                 azureAdConfiguration.VhUserApiResourceId);
 
-            testContext.GraphApiToken = new TokenProvider(azureAdConfigurationOptions).GetClientAccessToken(
+            testContext.GraphApiToken = new TokenProvider(azureAdConfiguration).GetClientAccessToken(
                 azureAdConfiguration.ClientId, azureAdConfiguration.ClientSecret,
                 "https://graph.microsoft.com");
 
-            var apiTestsOptions =
-                Options.Create(configRoot.GetSection("AcceptanceTestSettings").Get<AcceptanceTestConfiguration>());
-            var apiTestSettings = apiTestsOptions.Value;
-            testContext.BaseUrl = apiTestSettings.UserApiBaseUrl;
+            var apiTestsOptions = TestConfig.Instance.GetFromSection<AcceptanceTestConfiguration>("AcceptanceTestSettings");
+            testContext.BaseUrl = apiTestsOptions.UserApiBaseUrl;
         }
 
         [BeforeTestRun]

--- a/UserApi/UserApi.IntegrationTests/Controllers/ControllerTestsBase.cs
+++ b/UserApi/UserApi.IntegrationTests/Controllers/ControllerTestsBase.cs
@@ -35,13 +35,11 @@ namespace UserApi.IntegrationTests.Controllers
         {
             var testSettings = TestConfig.Instance.TestSettings;
 
-            var azureAdConfigOptions = Options.Create(TestConfig.Instance.AzureAd);
-            var azureAdConfiguration = azureAdConfigOptions.Value;
-            _bearerToken = new TokenProvider(azureAdConfigOptions).GetClientAccessToken(
+            _bearerToken = new TokenProvider(TestConfig.Instance.AzureAd).GetClientAccessToken(
                 testSettings.TestClientId, testSettings.TestClientSecret,
-                azureAdConfiguration.VhUserApiResourceId);
+                TestConfig.Instance.AzureAd.VhUserApiResourceId);
 
-            GraphApiToken = new TokenProvider(azureAdConfigOptions).GetClientAccessToken(
+            GraphApiToken = new TokenProvider(TestConfig.Instance.AzureAd).GetClientAccessToken(
                 testSettings.TestClientId, testSettings.TestClientSecret,
                 "https://graph.microsoft.com");
         }

--- a/UserApi/UserApi.IntegrationTests/Hooks/ApiHooks.cs
+++ b/UserApi/UserApi.IntegrationTests/Hooks/ApiHooks.cs
@@ -28,15 +28,14 @@ namespace UserApi.IntegrationTests.Hooks
         {
             apiTestContext.TestSettings = TestConfig.Instance.TestSettings;
 
-            var azureAdConfigOptions = Options.Create(TestConfig.Instance.AzureAd);
-            var azureAdConfiguration = azureAdConfigOptions.Value;
+            var azureAdConfig = TestConfig.Instance.AzureAd;
 
-            apiTestContext.BearerToken = new TokenProvider(azureAdConfigOptions).GetClientAccessToken(
+            apiTestContext.BearerToken = new TokenProvider(azureAdConfig).GetClientAccessToken(
                 apiTestContext.TestSettings.TestClientId, apiTestContext.TestSettings.TestClientSecret,
-                azureAdConfiguration.VhUserApiResourceId);
+                azureAdConfig.VhUserApiResourceId);
 
-            apiTestContext.GraphApiToken = new TokenProvider(azureAdConfigOptions).GetClientAccessToken(
-                azureAdConfiguration.ClientId, azureAdConfiguration.ClientSecret,
+            apiTestContext.GraphApiToken = new TokenProvider(azureAdConfig).GetClientAccessToken(
+                azureAdConfig.ClientId, azureAdConfig.ClientSecret,
                 "https://graph.microsoft.com");
         }
 

--- a/UserApi/UserApi.IntegrationTests/Services/ActiveDirectoryUserAccountServiceTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Services/ActiveDirectoryUserAccountServiceTests.cs
@@ -1,10 +1,7 @@
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Testing.Common;
-using UserApi.Common;
 using UserApi.Helper;
 using UserApi.Security;
 using UserApi.Services;
@@ -14,7 +11,6 @@ namespace UserApi.IntegrationTests.Services
     public class ActiveDirectoryUserAccountServiceTests
     {
         private UserAccountService _service;
-        private OptionsWrapper<AzureAdConfiguration> _configuration;
         private GraphApiSettings _graphApiSettings;
         private SecureHttpRequest _secureHttpRequest;
         private GraphApiClient _identityServiceApiClient;
@@ -23,11 +19,10 @@ namespace UserApi.IntegrationTests.Services
         public void Setup()
         {
             _secureHttpRequest = new SecureHttpRequest();
-            
-            _configuration = new OptionsWrapper<AzureAdConfiguration>(TestConfig.Instance.AzureAd);
-            var settings = new OptionsWrapper<Settings>(TestConfig.Instance.Settings);
-            var tokenProvider = new TokenProvider(_configuration);
-            _graphApiSettings = new GraphApiSettings(tokenProvider, _configuration);
+
+            var settings = TestConfig.Instance.Settings;
+            var tokenProvider = new TokenProvider(TestConfig.Instance.AzureAd);
+            _graphApiSettings = new GraphApiSettings(tokenProvider, TestConfig.Instance.AzureAd);
             _identityServiceApiClient = new GraphApiClient(_secureHttpRequest, _graphApiSettings);
             _service = new UserAccountService(_secureHttpRequest, _graphApiSettings, _identityServiceApiClient, settings);
         }

--- a/UserApi/UserApi.IntegrationTests/Services/GraphApiClientTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Services/GraphApiClientTests.cs
@@ -1,10 +1,7 @@
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Testing.Common;
-using UserApi.Common;
 using UserApi.Helper;
 using UserApi.Security;
 using UserApi.Services;
@@ -13,7 +10,6 @@ namespace UserApi.IntegrationTests.Services
 {
     public class GraphApiClientTests
     {
-        private OptionsWrapper<AzureAdConfiguration> _configuration;
         private GraphApiSettings _graphApiSettings;
         private SecureHttpRequest _secureHttpRequest;
         private GraphApiClient _graphApiClient;
@@ -23,8 +19,8 @@ namespace UserApi.IntegrationTests.Services
         {
             _secureHttpRequest = new SecureHttpRequest();
             
-            _configuration = new OptionsWrapper<AzureAdConfiguration>(TestConfig.Instance.AzureAd);
-            _graphApiSettings = new GraphApiSettings(new TokenProvider(_configuration), _configuration);
+            var config = TestConfig.Instance.AzureAd;
+            _graphApiSettings = new GraphApiSettings(new TokenProvider(config), config);
             _graphApiClient = new GraphApiClient(_secureHttpRequest, _graphApiSettings);
         }
 

--- a/UserApi/UserApi/ConfigureServicesExtensions.cs
+++ b/UserApi/UserApi/ConfigureServicesExtensions.cs
@@ -24,7 +24,6 @@ namespace UserApi
             serviceCollection.AddScoped<IUserAccountService, UserAccountService>();
             serviceCollection.AddScoped<ISecureHttpRequest, SecureHttpRequest>();
             serviceCollection.AddScoped<IGraphApiSettings, GraphApiSettings>();
-            serviceCollection.AddScoped<AzureAdConfiguration>();
             serviceCollection.BuildServiceProvider();
             serviceCollection.AddSwaggerToApi();
 

--- a/UserApi/UserApi/Helper/GraphApiSettings.cs
+++ b/UserApi/UserApi/Helper/GraphApiSettings.cs
@@ -18,21 +18,15 @@ namespace UserApi.Helper
         private readonly ITokenProvider _tokenProvider;
         private readonly AzureAdConfiguration _azureAdConfiguration;
 
-        public GraphApiSettings(ITokenProvider tokenProvider, IOptions<AzureAdConfiguration> azureAdConfigOptions)
+        public GraphApiSettings(ITokenProvider tokenProvider, AzureAdConfiguration azureAdConfig)
         {
             _tokenProvider = tokenProvider;
-            _azureAdConfiguration = azureAdConfigOptions.Value;
+            _azureAdConfiguration = azureAdConfig;
         }
 
-        public string GraphApiBaseUriWindows
-        {
-            get { return "https://graph.windows.net/"; }
-        }
+        public string GraphApiBaseUriWindows => "https://graph.windows.net/";
 
-        public string TenantId
-        {
-            get { return _azureAdConfiguration.TenantId; }
-        }
+        public string TenantId => _azureAdConfiguration.TenantId;
 
         public string AccessToken
         {
@@ -53,12 +47,6 @@ namespace UserApi.Helper
             }
         }
 
-        public string GraphApiBaseUri
-        {
-            get
-            {
-                return _azureAdConfiguration.GraphApiBaseUri;
-            }
-        }
+        public string GraphApiBaseUri => _azureAdConfiguration.GraphApiBaseUri;
     }
 }

--- a/UserApi/UserApi/Security/TokenProvider.cs
+++ b/UserApi/UserApi/Security/TokenProvider.cs
@@ -15,9 +15,9 @@ namespace UserApi.Security
     {
         private readonly AzureAdConfiguration _azureAdConfiguration;
 
-        public TokenProvider(IOptions<AzureAdConfiguration> azureAdConfiguration)
+        public TokenProvider(AzureAdConfiguration azureAdConfiguration)
         {
-            _azureAdConfiguration = azureAdConfiguration.Value;
+            _azureAdConfiguration = azureAdConfiguration;
         }
 
         public string GetClientAccessToken(string clientId, string clientSecret, string clientResource)

--- a/UserApi/UserApi/Services/UserAccountService.cs
+++ b/UserApi/UserApi/Services/UserAccountService.cs
@@ -27,13 +27,13 @@ namespace UserApi.Services
         private readonly IIdentityServiceApiClient _client;
         private readonly string _defaultPassword;
 
-        public UserAccountService(ISecureHttpRequest secureHttpRequest, IGraphApiSettings graphApiSettings, IIdentityServiceApiClient client, IOptions<Settings> settings)
+        public UserAccountService(ISecureHttpRequest secureHttpRequest, IGraphApiSettings graphApiSettings, IIdentityServiceApiClient client, Settings settings)
         {
             _retryTimeout = TimeSpan.FromSeconds(60);
             _secureHttpRequest = secureHttpRequest;
             _graphApiSettings = graphApiSettings;
             _client = client;
-            _defaultPassword = settings.Value.DefaultPassword;
+            _defaultPassword = settings.DefaultPassword;
         }
 
         public async Task<NewAdUserAccount> CreateUser(string firstName, string lastName, string displayName = null)

--- a/UserApi/UserApi/Startup.cs
+++ b/UserApi/UserApi/Startup.cs
@@ -22,7 +22,8 @@ namespace UserApi
             Configuration = configuration;
         }
 
-        public IConfiguration Configuration { get; }
+        private IConfiguration Configuration { get; }
+        private AzureAdConfiguration AzureAdSettings { get; set; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -32,7 +33,7 @@ namespace UserApi
             services.AddCors();
 
             ConfigureJsonSerialization(services);
-            RegisterSettings(services);
+            RegisterConfiguration(services);
 
             services.AddCustomTypes();
 
@@ -61,10 +62,11 @@ namespace UserApi
                     options.SerializerSettings.Converters.Add(new StringEnumConverter()));
         }
 
-        private void RegisterSettings(IServiceCollection services)
+        private void RegisterConfiguration(IServiceCollection services)
         {
-            services.Configure<AzureAdConfiguration>(options => Configuration.Bind("AzureAd", options));
-            services.Configure<Settings>(options => Configuration.Bind(options));
+            AzureAdSettings = Configuration.GetSection("AzureAd").Get<AzureAdConfiguration>();
+            services.AddSingleton(AzureAdSettings);
+            services.AddSingleton(Configuration.Get<Settings>());
         }
 
         private void RegisterAuth(IServiceCollection services)
@@ -75,17 +77,15 @@ namespace UserApi
 
             services.AddMvc(options => { options.Filters.Add(new AuthorizeFilter(policy)); });
 
-            var securitySettings = Configuration.GetSection("AzureAd").Get<AzureAdConfiguration>();
-
             services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
             }).AddJwtBearer(options =>
             {
-                options.Authority = $"{securitySettings.Authority}{securitySettings.TenantId}";
+                options.Authority = $"{AzureAdSettings.Authority}{AzureAdSettings.TenantId}";
                 options.TokenValidationParameters.ValidateLifetime = true;
-                options.Audience = securitySettings.VhUserApiResourceId;
+                options.Audience = AzureAdSettings.VhUserApiResourceId;
                 options.TokenValidationParameters.ClockSkew = TimeSpan.Zero;
             });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
By suggestion of @rehmanab, removing the use of IOptions, since we really don't need it.

Basically, the documentation says IOptions is usually used for named options (not sure what it is but we don't use it) or hot reloading of options, which by just unpacking the options using `.Value` we're also effectively not using.

So it's cleaner and easier simply to inject the actual settings classes.

https://docs.microsoft.com/en-gb/aspnet/core/fundamentals/configuration/options?view=aspnetcore-2.2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
