### PR TITLE
Adding trigger definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,12 @@ resources:
     ref: refs/heads/master # ref name to use, defaults to 'refs/heads/master'
     endpoint: 'GitHubDevOps'
 
+trigger:
+  tags:
+    include:
+    - v*
+
 jobs:
-  
 - template: jobs/angularDotNetCore.yml@azureDevOpsTemplates # Template reference
   parameters:
     cleanCheckout: $(cleanCheckout)


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

This change adds trigger definition to the pipeline.
If build triggers are not specified for a git branch any change to a branch or a  new branch will trigger a new build.
To trigger a build from a tag the tag trigger definition has to be present in the build pipeline - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#tags

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
