### PR TITLE
Switched to using the videohearings team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ddikman @RuwanikaWeerakkody @npoxon @abitec
-
+* @hmcts/VH


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Attempted to set the entire vh-team as codeowners to automatically get PRs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
