### PR TITLE
VIH-8407 Sanitise names containing fullstops

### DIFF
--- a/UserApi/UserApi.UnitTests/Services/GraphApiClientTests.cs
+++ b/UserApi/UserApi.UnitTests/Services/GraphApiClientTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -41,8 +42,9 @@ namespace UserApi.UnitTests.Services
         [Test]
         public async Task Should_create_user_successfully_and_return_NewAdUserAccount()
         {
-            var username = "TestTester";
-            var firstName = "Test";
+            var periodRegexString = "^\\.|\\.$";
+            var username = ".TestTester.";
+            var firstName = ".Test.";
             var lastName = "Tester";
             var recoveryEmail = "test'tester@hmcts.net";
             var displayName = $"{firstName} {lastName}";
@@ -51,7 +53,8 @@ namespace UserApi.UnitTests.Services
                 displayName,
                 givenName = firstName,
                 surname = lastName,
-                mailNickname = $"{firstName}.{lastName}".ToLower(),
+                mailNickname = $"{Regex.Replace(firstName, periodRegexString, string.Empty)}.{Regex.Replace(lastName, periodRegexString, string.Empty)}"
+                    .ToLower(),
                 otherMails = new List<string> { recoveryEmail },
                 accountEnabled = true,
                 userPrincipalName = username,

--- a/UserApi/UserApi.UnitTests/Services/UserAccountService/UserAccountServiceTests.cs
+++ b/UserApi/UserApi.UnitTests/Services/UserAccountService/UserAccountServiceTests.cs
@@ -115,6 +115,19 @@ namespace UserApi.UnitTests.Services.UserAccountService
         }
 
         [Test]
+        public async Task Should_sanitise_names()
+        {
+            const string firstName = ".First.";
+            const string lastName = ".La.st.";
+            var baseUsername = "First.La.st".ToLowerInvariant();
+
+            var nextAvailable = await Service.CheckForNextAvailableUsernameAsync(firstName, lastName);
+
+            nextAvailable.Should().Be(baseUsername + Domain);
+            IdentityServiceApiClient.Verify(i => i.GetUsernamesStartingWithAsync(baseUsername), Times.Once);
+        }
+
+        [Test]
         public async Task Should_delete()
         {
             IdentityServiceApiClient.Setup(x => x.DeleteUserAsync(It.IsAny<string>()))

--- a/UserApi/UserApi/Services/GraphApiClient.cs
+++ b/UserApi/UserApi/Services/GraphApiClient.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UserApi.Helper;
@@ -54,6 +55,8 @@ namespace UserApi.Services
 
         public async Task<NewAdUserAccount> CreateUserAsync(string username, string firstName, string lastName, string displayName, string recoveryEmail, bool isTestUser = false)
         {
+            var periodRegexString = "^\\.|\\.$";
+
             // the user object provided by the graph api nuget package is missing the otherMails property
             // but it's there in the API so using a dynamic request model instead
             var newPassword = isTestUser ? _testDefaultPassword : _passwordService.GenerateRandomPasswordWithDefaultComplexity();
@@ -62,7 +65,8 @@ namespace UserApi.Services
                 displayName,
                 givenName = firstName,
                 surname = lastName,
-                mailNickname = $"{firstName}.{lastName}".ToLower(),
+                mailNickname = $"{Regex.Replace(firstName, periodRegexString, string.Empty)}.{Regex.Replace(lastName, periodRegexString, string.Empty)}"
+                    .ToLower(),
                 otherMails = new List<string> { recoveryEmail },
                 accountEnabled = true,
                 userPrincipalName = username,

--- a/UserApi/UserApi/Services/UserAccountService.cs
+++ b/UserApi/UserApi/Services/UserAccountService.cs
@@ -12,6 +12,8 @@ using UserApi.Contract.Responses;
 using UserApi.Helper;
 using UserApi.Security;
 using UserApi.Services.Models;
+using System.Text.RegularExpressions;
+using Group = Microsoft.Graph.Group;
 
 namespace UserApi.Services
 {
@@ -237,9 +239,14 @@ namespace UserApi.Services
         /// <returns>next available user principal name</returns>
         public async Task<string> CheckForNextAvailableUsernameAsync(string firstName, string lastName)
         {
-            var noSpaceFirstName = firstName.Replace(" ", string.Empty);
-            var noSpaceLastName = lastName.Replace(" ", string.Empty);
-            var baseUsername = $"{noSpaceFirstName}.{noSpaceLastName}".ToLowerInvariant();
+            var periodRegexString = "^\\.|\\.$";
+            var sanitisedFirstName = Regex.Replace(firstName, periodRegexString, string.Empty);
+            var sanitisedLastName = Regex.Replace(lastName, periodRegexString, string.Empty);
+
+            sanitisedFirstName = Regex.Replace(sanitisedFirstName, " ", string.Empty);
+            sanitisedLastName = Regex.Replace(sanitisedLastName, " ", string.Empty);
+
+            var baseUsername = $"{sanitisedFirstName}.{sanitisedLastName}".ToLowerInvariant();
             var username = new IncrementingUsername(baseUsername, _settings.ReformEmail);
             var existingUsernames = await GetUsersMatchingNameAsync(baseUsername);
             return username.GetGivenExistingUsers(existingUsernames);


### PR DESCRIPTION
Names that start or end with a period were causing user api exceptions when it comes to auto generating the reforms email, as it would result in two periods coming together or a a period and an @ coming together.

The fix saves the names as entered, but strips the names of any leading/ending periods when it comes to generating the email.