### PR TITLE
VIH-9151 Fix failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,10 @@ Package.StoreAssociation.xml
 _pkginfo.txt
 *.appx
 
+# MacOS Desktop Services Store files
+.DS_Store
+*.DS_Store
+
 # Visual Studio cache files
 # files ending in .cache can be ignored
 *.[Cc]ache

--- a/UserApi/UserApi/UserApi.csproj
+++ b/UserApi/UserApi/UserApi.csproj
@@ -17,14 +17,6 @@
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
-  <Target Name="AssemblyVersionAttributes" BeforeTargets="BeforeBuild" Condition=" '$(Configuration)' != 'Debug' ">
-    <PropertyGroup>
-      <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-      <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-      <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-    </PropertyGroup>
-  </Target>
-
   <PropertyGroup>
       <UseAppHost>false</UseAppHost>
   </PropertyGroup>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9151


### Change description ###
Fixes a failing test which asserts assembly version information. This is caused by the version numbers not being generated when the app is run in Release mode.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
