### PR TITLE
VIH-9257 Support slashes in email addresses

### DIFF
--- a/UserApi/UserApi.IntegrationTests/Controllers/UserControllerTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Controllers/UserControllerTests.cs
@@ -278,6 +278,21 @@ namespace UserApi.IntegrationTests.Controllers
             updatedUserResponse.LastName.Should().Be(updateUserRequest.LastName);
             updatedUserResponse.Email.Should().NotBe(username);
         }
+
+        [Test]
+        public async Task Should_get_user_by_email_containing_slash()
+        {
+            var email = "Automation02/Individual01@hmcts.net";
+            var getResponse = await SendGetRequestAsync(GetUserByEmail(email));
+            getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var userResponseModel = RequestHelper.Deserialise<UserProfile>(getResponse.Content
+                .ReadAsStringAsync().Result);
+            userResponseModel.UserName.Should().NotBeNullOrWhiteSpace();
+            userResponseModel.Email.Should().NotBeNullOrWhiteSpace();
+            userResponseModel.FirstName.Should().NotBeNullOrWhiteSpace();
+            userResponseModel.LastName.Should().NotBeNullOrWhiteSpace();
+            userResponseModel.UserRole.Should().NotBeNullOrWhiteSpace();
+        }
         
         [TearDown]
         public async Task ClearUp()

--- a/UserApi/UserApi/Controllers/UserController.cs
+++ b/UserApi/UserApi/Controllers/UserController.cs
@@ -149,7 +149,7 @@ namespace UserApi.Controllers
         /// <summary>
         ///     Get user profile by email
         /// </summary>
-        [HttpGet("email/{email?}", Name = "GetUserByEmail")]
+        [HttpGet("email/{**email}", Name = "GetUserByEmail")]
         [OpenApiOperation("GetUserByEmail")]
         [ProducesResponseType(typeof(UserProfile), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9257


### Change description ###
Creating a hearing with participants containing slashes in their email address currently fails as the slash doesn't get url decoded, causing the user lookups to fail.

Fix by changing the contactEmail to a catch-all parameter (**) which supports slashes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```