### PR TITLE
VIH-9664 Disable zap tests

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -23,7 +23,7 @@ parameters:
 - name: RunZap
   displayName: Execute ZAP Tests
   type: boolean
-  default: true
+  default: false
 
 - name: prodEnvs
   displayName: Environments Using Prod Subscription


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9664


### Change description ###
Disables zap tests, like the other apps. This is needed to fix deployments as the container registry required by the zap tests no longer exist


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
