### PR TITLE
VIH-9428 - Participant Email Property otherMails has an invalid 

### DIFF
--- a/UserApi/UserApi.IntegrationTests/Services/UserAccountServiceTests.cs
+++ b/UserApi/UserApi.IntegrationTests/Services/UserAccountServiceTests.cs
@@ -82,7 +82,18 @@ namespace UserApi.IntegrationTests.Services
 
             await ActiveDirectoryUser.DeleteTheUserFromAdAsync(username, _graphApiSettings.AccessToken);
         }
-   
+
+        [Test]
+        public void should_throw_exception_when_attempting_to_create_user_with_invalid_email()
+        {
+            const string firstName = "Automatically";
+            const string lastName = "Created";
+            var unique = DateTime.Now.ToString("yyyyMMddhmmss");
+            var recoveryEmail = $"{firstName}.{lastName}.{unique}.@{TestConfig.Instance.Settings.ReformEmail}";
+            var result = Assert.ThrowsAsync<InvalidEmailException>(() => _service.CreateUserAsync(firstName, lastName, recoveryEmail, false));
+            result.Email.Should().Be(recoveryEmail);
+        }
+
         [Test]
         public void should_throw_exception_when_attempting_to_delete_nonexistent_user()
         {

--- a/UserApi/UserApi.IntegrationTests/useraccounts.json
+++ b/UserApi/UserApi.IntegrationTests/useraccounts.json
@@ -5,35 +5,35 @@
       "Firstname": "Automation01",
       "Lastname": "UA_CaseAdmin01",
       "DisplayName": "Automation01_UA_CaseAdmin01",
-      "AlternativeEmail": "g5@a.com"
+      "AlternativeEmail": "g5@email.com"
     },
     {
       "Role": "Individual",
       "Firstname": "Automation01",
       "Lastname": "UA_Individual01",
       "DisplayName": "Automation01_UA_Individual01",
-      "AlternativeEmail": "g2@a.com"
+      "AlternativeEmail": "g2@email.com"
     },
     {
       "Role": "Judge",
       "Firstname": "Automation01",
       "Lastname": "UA_Judge01",
       "DisplayName": "Automation01_UA_Judge01",
-      "AlternativeEmail": "g1@a.com"
+      "AlternativeEmail": "g1@email.com"
     },
     {
       "Role": "Representative",
       "Firstname": "Automation01",
       "Lastname": "UA_Representative01",
       "DisplayName": "Automation01_UA_Representative01",
-      "AlternativeEmail": "g3@a.com"
+      "AlternativeEmail": "g3@email.com"
     },
     {
       "Role": "VhOfficer",
       "Firstname": "Automation01",
       "Lastname": "UA_VideoHearingsOfficer01",
       "DisplayName": "Automation01_UA_VideoHearingsOfficer01",
-      "AlternativeEmail": "g4@a.com"
+      "AlternativeEmail": "g4@email.com"
     }
   ]
 }

--- a/UserApi/UserApi.IntegrationTests/useraccounts.json
+++ b/UserApi/UserApi.IntegrationTests/useraccounts.json
@@ -5,35 +5,35 @@
       "Firstname": "Automation01",
       "Lastname": "UA_CaseAdmin01",
       "DisplayName": "Automation01_UA_CaseAdmin01",
-      "AlternativeEmail": "g5@email.com"
+      "AlternativeEmail": "g5@a.com"
     },
     {
       "Role": "Individual",
       "Firstname": "Automation01",
       "Lastname": "UA_Individual01",
       "DisplayName": "Automation01_UA_Individual01",
-      "AlternativeEmail": "g2@email.com"
+      "AlternativeEmail": "g2@a.com"
     },
     {
       "Role": "Judge",
       "Firstname": "Automation01",
       "Lastname": "UA_Judge01",
       "DisplayName": "Automation01_UA_Judge01",
-      "AlternativeEmail": "g1@email.com"
+      "AlternativeEmail": "g1@a.com"
     },
     {
       "Role": "Representative",
       "Firstname": "Automation01",
       "Lastname": "UA_Representative01",
       "DisplayName": "Automation01_UA_Representative01",
-      "AlternativeEmail": "g3@email.com"
+      "AlternativeEmail": "g3@a.com"
     },
     {
       "Role": "VhOfficer",
       "Firstname": "Automation01",
       "Lastname": "UA_VideoHearingsOfficer01",
       "DisplayName": "Automation01_UA_VideoHearingsOfficer01",
-      "AlternativeEmail": "g4@email.com"
+      "AlternativeEmail": "g4@a.com"
     }
   ]
 }

--- a/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
+++ b/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
@@ -104,6 +104,17 @@ namespace UserApi.UnitTests.Controllers
         }
 
         [Test]
+        public async Task Should_return_ConflictObjectResult_with_InvalidEmailException()
+        {
+            _userAccountService.Setup(u => u.CreateUserAsync(_request.FirstName, _request.LastName, _request.RecoveryEmail, _request.IsTestUser)).ThrowsAsync(new InvalidEmailException("Recovery email is not a valid email", _request.RecoveryEmail));
+            var actionResult = (ConflictObjectResult)await _controller.CreateUser(_request);
+
+            actionResult.Should().NotBeNull();
+            actionResult.StatusCode.Should().Be((int)HttpStatusCode.Conflict);
+            actionResult.Value.ToString().Should().Be($"{{ Message = Recovery email is not a valid email, Code = InvalidEmail, Email = {_request.RecoveryEmail} }}");
+        }
+
+        [Test]
         public async Task Should_get_user_by_user_id_from_api()
         {
             string userId = Guid.NewGuid().ToString();

--- a/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
+++ b/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
@@ -104,18 +104,6 @@ namespace UserApi.UnitTests.Controllers
         }
 
         [Test]
-        public async Task Should_return_ConflictObjectResult_with_InvalidEmailException()
-        {
-            _userAccountService.Setup(u => u.CreateUserAsync(_request.FirstName, _request.LastName, _request.RecoveryEmail, _request.IsTestUser)).ThrowsAsync(new InvalidEmailException("Recovery email is invalid", _request.RecoveryEmail));
-
-            var actionResult = (ConflictObjectResult)await _controller.CreateUser(_request);
-
-            actionResult.Should().NotBeNull();
-            actionResult.StatusCode.Should().Be((int)HttpStatusCode.Conflict);
-            actionResult.Value.ToString().Should().Be($"{{ Message = Recovery email is invalid, Code = InvalidEmail, Email = {_request.RecoveryEmail} }}");
-        }
-
-        [Test]
         public async Task Should_get_user_by_user_id_from_api()
         {
             string userId = Guid.NewGuid().ToString();

--- a/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
+++ b/UserApi/UserApi.UnitTests/Controllers/UserControllerTests.cs
@@ -104,6 +104,18 @@ namespace UserApi.UnitTests.Controllers
         }
 
         [Test]
+        public async Task Should_return_ConflictObjectResult_with_InvalidEmailException()
+        {
+            _userAccountService.Setup(u => u.CreateUserAsync(_request.FirstName, _request.LastName, _request.RecoveryEmail, _request.IsTestUser)).ThrowsAsync(new InvalidEmailException("Recovery email is invalid", _request.RecoveryEmail));
+
+            var actionResult = (ConflictObjectResult)await _controller.CreateUser(_request);
+
+            actionResult.Should().NotBeNull();
+            actionResult.StatusCode.Should().Be((int)HttpStatusCode.Conflict);
+            actionResult.Value.ToString().Should().Be($"{{ Message = Recovery email is invalid, Code = InvalidEmail, Email = {_request.RecoveryEmail} }}");
+        }
+
+        [Test]
         public async Task Should_get_user_by_user_id_from_api()
         {
             string userId = Guid.NewGuid().ToString();
@@ -169,7 +181,6 @@ namespace UserApi.UnitTests.Controllers
             actionResult.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
             ((ModelStateDictionary)actionResult.Value).ContainsKeyAndErrorMessage(nameof(userId), "user does not exist");
         }
-
 
         [Test]
         public async Task Should_get_user_by_user_name_from_api()
@@ -277,7 +288,10 @@ namespace UserApi.UnitTests.Controllers
         [Test]
         public async Task Should_return_badrequest_with_invalid_email()
         {
-            var email = "invalid@email@com";
+            const string firstName = "Automatically";
+            const string lastName = "Created";
+            var unique = DateTime.Now.ToString("yyyyMMddhmmss");
+            var email = $"{firstName}.{lastName}.{unique}.@hearings.reform.hmcts.net"; // dot before @ is invalid email formatting
 
             var actionResult = (NotFoundObjectResult)await _controller.GetUserByEmail(email);
             actionResult.Should().NotBeNull();

--- a/UserApi/UserApi.UnitTests/Services/UserAccountService/CreateUserAsyncTests.cs
+++ b/UserApi/UserApi.UnitTests/Services/UserAccountService/CreateUserAsyncTests.cs
@@ -13,7 +13,7 @@ namespace UserApi.UnitTests.Services.UserAccountService
 {
     public class CreateUserAsyncTests: UserAccountServiceTests
     {
-        private const string RecoveryEmail = "test'email@com";
+        private const string RecoveryEmail = "test'email@a.com";
         private NewAdUserAccount _newAdUserAccount;
 
         [SetUp]

--- a/UserApi/UserApi.UnitTests/Services/UserAccountService/CreateUserAsyncTests.cs
+++ b/UserApi/UserApi.UnitTests/Services/UserAccountService/CreateUserAsyncTests.cs
@@ -62,5 +62,17 @@ namespace UserApi.UnitTests.Services.UserAccountService
 
             response.Message.Should().Be("User with recovery email already exists");
         }
+
+        //Recovery email is not a valid email
+        [Test]
+        public void Should_return_recovery_email_is_not_valid()
+        {
+            var invalidRecoveryEmail = "email.@email.com";
+            Filter = $"otherMails/any(c:c eq '{invalidRecoveryEmail.Replace("'", "''")}')";
+
+            var response = Assert.ThrowsAsync<InvalidEmailException>(async () => await Service.CreateUserAsync("fName", "lName", invalidRecoveryEmail, false));
+
+            response.Message.Should().Be("Recovery email is not a valid email");
+        }
     }
 }

--- a/UserApi/UserApi.UnitTests/ValidateArguments/EmailValidationTests.cs
+++ b/UserApi/UserApi.UnitTests/ValidateArguments/EmailValidationTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using System;
+using Faker;
+using UserApi.Validations;
+using FluentAssertions;
+
+namespace UserApi.UnitTests.ValidateArguments
+{
+    public class EmailValidationTests
+    {
+        [Test]
+        public void Should_pass_validation_with_good_email()
+        {
+            var email = $"{RandomNumber.Next()}@hmcts.net";
+            email.IsValidEmail().Should().BeTrue();
+        }
+
+        [Test]
+        public void Should_fail_validation_when_empty()
+        {
+            var email = string.Empty;
+            email.IsValidEmail().Should().BeFalse();
+        }
+
+        [Test]
+        public void Should_fail_validation_when_format_is_invalid()
+        {
+            const string firstName = "Automatically";
+            const string lastName = "Created";
+            var unique = DateTime.Now.ToString("yyyyMMddhmmss");
+            var email = $"{firstName}.{lastName}.{unique}.@hearings.reform.hmcts.net";
+
+            email.IsValidEmail().Should().BeFalse();
+        }
+    }
+}

--- a/UserApi/UserApi.UnitTests/ValidateArguments/UserValidateArgumentTests.cs
+++ b/UserApi/UserApi.UnitTests/ValidateArguments/UserValidateArgumentTests.cs
@@ -32,7 +32,7 @@ namespace UserApi.UnitTests.ValidateArguments
         public async Task Should_return_email_error()
         {
             var request = BuildRequest();
-            request.RecoveryEmail = "badEmail";
+            request.RecoveryEmail = "badEmail.@email.com";
             var result = await _validator.ValidateAsync(request);
 
             result.IsValid.Should().BeFalse();

--- a/UserApi/UserApi/Controllers/UserController.cs
+++ b/UserApi/UserApi/Controllers/UserController.cs
@@ -84,6 +84,15 @@ namespace UserApi.Controllers
                     e.Username
                 });
             }
+            catch (InvalidEmailException e) 
+            {
+                return new ConflictObjectResult(new
+                {
+                    Message = "Recovery email is invalid",
+                    Code = "InvalidEmail",
+                    e.Email
+                });
+            }
         }
 
         /// <summary>
@@ -161,8 +170,8 @@ namespace UserApi.Controllers
                 ModelState.AddModelError(nameof(email), "email cannot be empty");
                 return BadRequest(ModelState);
             }
-            
-            if (!(new EmailAddressAttribute().IsValid(email)))
+
+            if (!email.IsValidEmail())
             {
                 ModelState.AddModelError(nameof(email), "email does not exist");
                 return NotFound(ModelState);

--- a/UserApi/UserApi/Controllers/UserController.cs
+++ b/UserApi/UserApi/Controllers/UserController.cs
@@ -88,7 +88,7 @@ namespace UserApi.Controllers
             {
                 return new ConflictObjectResult(new
                 {
-                    Message = "Recovery email is invalid",
+                    Message = e.Message,
                     Code = "InvalidEmail",
                     e.Email
                 });

--- a/UserApi/UserApi/Services/IUserAccountService.cs
+++ b/UserApi/UserApi/Services/IUserAccountService.cs
@@ -13,6 +13,7 @@ namespace UserApi.Services
         /// Creates a new user with a username based on first and last name
         /// </summary>
         /// <exception cref="UserExistsException">Thrown if a user with the recovery email already exists</exception>
+        /// <exception cref="InvalidEmailException">Thrown if the recovery email has an invalid email format</exception>
         Task<NewAdUserAccount> CreateUserAsync(string firstName, string lastName, string recoveryEmail, bool isTestUser);
         Task<User> UpdateUserAccountAsync(Guid userId, string firstName, string lastName);
         Task DeleteUserAsync(string username);

--- a/UserApi/UserApi/Services/InvalidEmailException.cs
+++ b/UserApi/UserApi/Services/InvalidEmailException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace UserApi.Services
+{
+    [Serializable]
+    public class InvalidEmailException : Exception
+    {
+        protected InvalidEmailException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+
+        public InvalidEmailException(string message, string email) : base(message)
+        {
+            Email = email;
+        }
+
+        public string Email { get; }
+    }
+}

--- a/UserApi/UserApi/Services/InvalidEmailException.cs
+++ b/UserApi/UserApi/Services/InvalidEmailException.cs
@@ -7,7 +7,7 @@ namespace UserApi.Services
     public class InvalidEmailException : Exception
     {
         protected InvalidEmailException(SerializationInfo info, StreamingContext context) : base(info, context)
-        { }
+        {}
 
         public InvalidEmailException(string message, string email) : base(message)
         {

--- a/UserApi/UserApi/Services/UserAccountService.cs
+++ b/UserApi/UserApi/Services/UserAccountService.cs
@@ -16,6 +16,7 @@ using UserApi.Services.Models;
 using System.Text.RegularExpressions;
 using UserApi.Mappers;
 using Group = Microsoft.Graph.Group;
+using UserApi.Validations;
 
 namespace UserApi.Services
 {
@@ -47,6 +48,11 @@ namespace UserApi.Services
         public async Task<NewAdUserAccount> CreateUserAsync(string firstName, string lastName, string recoveryEmail,
             bool isTestUser)
         {
+            if (!recoveryEmail.IsValidEmail())
+            {
+                throw new InvalidEmailException("Recovery email is not a valid email", recoveryEmail);
+            }
+
             var recoveryEmailText = recoveryEmail.Replace("'", "''");
             var filter = $"otherMails/any(c:c eq '{recoveryEmailText}')";
             var user = await GetUserByFilterAsync(filter);

--- a/UserApi/UserApi/Validations/CreateUserRequestValidation.cs
+++ b/UserApi/UserApi/Validations/CreateUserRequestValidation.cs
@@ -10,7 +10,7 @@ namespace UserApi.Validations
             RuleFor(x => x.FirstName).NotEmpty().WithMessage(MissingFirstNameErrorMessage);
             RuleFor(x => x.LastName).NotEmpty().WithMessage(MissingLastNameErrorMessage);
             RuleFor(x => x.RecoveryEmail).NotEmpty().WithMessage(MissingEmailErrorMessage);
-            RuleFor(x => x.RecoveryEmail).EmailAddress().WithMessage(InvalidEmailErrorMessage);
+            RuleFor(x => x.RecoveryEmail).Must(x => x.IsValidEmail()).WithMessage(InvalidEmailErrorMessage);
         }
 
         public static string MissingFirstNameErrorMessage => "first name cannot be empty";

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -6,7 +6,7 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
-        private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|\[[\t -Z^-~]*])*$";
+        private const string RegexPattern = @"^([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)*)@([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)+|[[\t -Z^-~]*])+$";
 
         /// <summary>
         /// Test if the given string is specified and a valid email address

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -6,7 +6,7 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
-        private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
+        private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|\[[\t -Z^-~]*])*$";
 
         /// <summary>
         /// Test if the given string is specified and a valid email address

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -7,6 +7,7 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
+        private static TimeSpan RegexTimeOut = TimeSpan.FromSeconds(4);
         private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
 
         /// <summary>
@@ -20,7 +21,7 @@ namespace UserApi.Validations
             if (string.IsNullOrEmpty(email))
                 return false;
 
-            var r = Regex.Match(email, RegexPattern);
+            var r = Regex.Match(email, RegexPattern, RegexOptions.None, RegexTimeOut);
             return r.Success;
         }
     }

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Net.Mail;
+using System.Text.RegularExpressions;
+
+namespace UserApi.Validations
+{
+    /// <summary>Simple validator to check email formats</summary>
+    public static class EmailValidation
+    {
+        private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
+
+        /// <summary>
+        /// Test if the given string is specified and a valid email address
+        /// </summary>
+        /// <remarks>
+        /// This was recommended one of the simplest way to manage email validation.
+        /// </remarks>
+        public static bool IsValidEmail(this string email)
+        {
+            if (string.IsNullOrEmpty(email))
+                return false;
+
+            try
+            {
+                var r = Regex.Match(email, RegexPattern);
+                return r.Success;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -6,7 +6,7 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
-        private const string RegexPattern = @"^([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)*)@([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)+|[[\t -Z^-~]*])+$";
+        private const string RegexPattern = @"^([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)*)@([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)+)+$";
 
         /// <summary>
         /// Test if the given string is specified and a valid email address

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -20,15 +20,8 @@ namespace UserApi.Validations
             if (string.IsNullOrEmpty(email))
                 return false;
 
-            try
-            {
-                var r = Regex.Match(email, RegexPattern);
-                return r.Success;
-            }
-            catch (FormatException)
-            {
-                return false;
-            }
+            var r = Regex.Match(email, RegexPattern);
+            return r.Success;
         }
     }
 }

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Mail;
 using System.Text.RegularExpressions;
 
 namespace UserApi.Validations
@@ -7,7 +6,6 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
-        private static TimeSpan RegexTimeOut = TimeSpan.FromSeconds(4);
         private const string RegexPattern = @"^([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*)@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(?:[a-zA-Z0-9](?:\.[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
 
         /// <summary>
@@ -20,16 +18,9 @@ namespace UserApi.Validations
         {
             if (string.IsNullOrEmpty(email))
                 return false;
-            
-            try 
-            { 
-                var r = Regex.Match(email, RegexPattern, RegexOptions.None, RegexTimeOut);
-                return r.Success;
-            }
-            catch(RegexMatchTimeoutException)
-            {
-                return false;
-            }
+
+            var match = Regex.Match(email, RegexPattern);
+            return match.Success;
         }
     }
 }

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -6,7 +6,7 @@ namespace UserApi.Validations
     /// <summary>Simple validator to check email formats</summary>
     public static class EmailValidation
     {
-        private const string RegexPattern = @"^([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)*)@([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)+)+$";
+        private const string RegexPattern = @"^([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)*)@([!#-'*/-9=?A-Z^-~-]+(\.[!#-'*/-9=?A-Z^-~-]+)+)$";
 
         /// <summary>
         /// Test if the given string is specified and a valid email address

--- a/UserApi/UserApi/Validations/EmailValidation.cs
+++ b/UserApi/UserApi/Validations/EmailValidation.cs
@@ -20,9 +20,16 @@ namespace UserApi.Validations
         {
             if (string.IsNullOrEmpty(email))
                 return false;
-
-            var r = Regex.Match(email, RegexPattern, RegexOptions.None, RegexTimeOut);
-            return r.Success;
+            
+            try 
+            { 
+                var r = Regex.Match(email, RegexPattern, RegexOptions.None, RegexTimeOut);
+                return r.Success;
+            }
+            catch(RegexMatchTimeoutException)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/VIH-9428

1. Added the EmailValidation class which contains a Regex matching Pattern to validate email addresses
2. GetUserByEmail in UserController no longer validates email using EmailAddressAttribute class. It now validates using the EmailValidation class
3. Created the InvalidEmailException class
4. UserAccountService will now validate the email via the EmailValidation class and throw an InvalidEmailException should the regex pattern not match the input
5. The CreateUser function in the UserController now has a catch for InvalidEmailExceptions
6. Updated the CreateUserRequestValidation validations. Instead of using the EmailAddress rule, it now uses the Regex within the EmailValidation class
7. Created tests to validate the changes made