### PR TITLE
VIH-9770 Fix for app not logging to app insights

### DIFF
--- a/UserApi/UserApi/Startup.cs
+++ b/UserApi/UserApi/Startup.cs
@@ -57,8 +57,7 @@ namespace UserApi
             RegisterAuth(services);
             services.AddMvc()
                 .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<AddUserToGroupRequestValidation>());
-            services.AddApplicationInsightsTelemetry(options =>
-                options.ConnectionString = Configuration["ApplicationInsights:InstrumentationKey"]);
+            services.AddApplicationInsightsTelemetry(Configuration["ApplicationInsights:InstrumentationKey"]);
             services.AddSingleton<IFeatureToggles>(new FeatureToggles(Configuration["FeatureToggle:SdkKey"]));
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9770


### Change description ###
Reverts a change recently made which is causing issues sending telemetry to app insights.

This requires using an obsolete method, which is necessary until we can update the secrets to the new format.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
